### PR TITLE
Bbmap filterbyname config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tests/data/
 __pycache__
 *.pyo
 *.pyc
+build/
+involucro

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ tests/data/
 __pycache__
 *.pyo
 *.pyc
-build/
-involucro
+

--- a/modules/nf-core/bbmap/filterbyname/meta.yml
+++ b/modules/nf-core/bbmap/filterbyname/meta.yml
@@ -14,6 +14,31 @@ tools:
       licence: ["UC-LBL license (see package)"]
 
 input:
+  - args:
+      type: map
+      description: |
+        Groovy Map containing extra parameters.
+
+        This map MUST follow the structure/keywords below and be provided via
+        modules.config.Parameters must be set between quotes, unless it is a
+        boolean value.
+        All (optional) parameters can be removed from the map, if they are not
+        set.
+
+        "args" corresponds to parameters for the tool itself (see documentation
+        above)
+        The rest of keys control how the tool runs.
+
+        ```
+        {
+          [
+            "args"              : ""                    (optional),
+            "output_extension"  : "extension of $reads" (optional),
+            "interleaved_output": false                 (optional)
+          ]
+        }
+        ```
+
   - meta:
       type: map
       description: |
@@ -24,11 +49,6 @@ input:
       description: |
         List of input FastQ files of size 1 and 2 for single-end and
         paired-end data, respectively.
-  - output_extension:
-      type: string
-      description: |
-        Desired file extension for the output file (for example, "fastq", "fa",
-        "fq.gz", etc)
   - names:
       type: string
       description: A comma-separated list of strings or files. The files can have one name per

--- a/modules/nf-core/bbmap/filterbyname/meta.yml
+++ b/modules/nf-core/bbmap/filterbyname/meta.yml
@@ -71,7 +71,7 @@ output:
   - log:
       type: file
       description: filterbyname.sh log file
-      pattern: "*filterbyname.log"
+      pattern: "*.filterbyname.log"
 
 authors:
   - "@tokarevvasily"

--- a/tests/modules/nf-core/bbmap/filterbyname/main.nf
+++ b/tests/modules/nf-core/bbmap/filterbyname/main.nf
@@ -2,7 +2,7 @@
 
 nextflow.enable.dsl = 2
 
-include { BBMAP_FILTERBYNAME } from '../../../../../modules/nf-core/bbmap/filterbyname/main.nf'
+include { BBMAP_FILTERBYNAME as BBMAP_FILTERBYNAME } from '../../../../../modules/nf-core/bbmap/filterbyname/main.nf'
 
 workflow test_bbmap_filterbyname_paired_end {
     
@@ -13,10 +13,9 @@ workflow test_bbmap_filterbyname_paired_end {
             file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
         ]
     ]
-    output_extension = ".fa"
     names = "ERR5069949.2151832,ERR5069949.576388,ERR5069949.501486"
 
-    BBMAP_FILTERBYNAME ( input, output_extension, names )
+    BBMAP_FILTERBYNAME ( input, names )
 }
 
 workflow test_bbmap_filterbyname_single_end {
@@ -27,8 +26,7 @@ workflow test_bbmap_filterbyname_single_end {
             file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
         ]
     ]
-    output_extension = ".fa"
     names = "ERR5069949.2151832,ERR5069949.576388,ERR5069949.501486"
 
-    BBMAP_FILTERBYNAME ( input, output_extension, names )
+    BBMAP_FILTERBYNAME ( input, names )
 }

--- a/tests/modules/nf-core/bbmap/filterbyname/nextflow.config
+++ b/tests/modules/nf-core/bbmap/filterbyname/nextflow.config
@@ -1,5 +1,12 @@
 process {
 
     publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
-    
+
+    withName: 'test_bbmap_filterbyname_paired_end:BBMAP_FILTERBYNAME' {
+        ext.args = [
+            output_extension : "fasta",
+            interleaved_output : true
+        ]
+    }
+
 }

--- a/tests/modules/nf-core/bbmap/filterbyname/test.yml
+++ b/tests/modules/nf-core/bbmap/filterbyname/test.yml
@@ -7,7 +7,6 @@
   - path: output/bbmap/test.fasta
     md5sum: b03f20541df9eb3053f8fb507a6c124f
   - path: output/bbmap/test.filterbyname.log
-    contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
 
 - name: bbmap filterbyname test_bbmap_filterbyname_single_end
   command: nextflow run ./tests/modules/nf-core/bbmap/filterbyname -entry test_bbmap_filterbyname_single_end -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/bbmap/filterbyname/nextflow.config
@@ -18,4 +17,3 @@
   - path: output/bbmap/test.fastq.gz
     md5sum: ddc04fd7fd192c9c61aea553d50669e0
   - path: output/bbmap/test.filterbyname.log
-    contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'

--- a/tests/modules/nf-core/bbmap/filterbyname/test.yml
+++ b/tests/modules/nf-core/bbmap/filterbyname/test.yml
@@ -1,8 +1,8 @@
 - name: bbmap filterbyname test_bbmap_filterbyname_paired_end
   command: nextflow run ./tests/modules/nf-core/bbmap/filterbyname -entry test_bbmap_filterbyname_paired_end -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/bbmap/filterbyname/nextflow.config
   tags:
-  - bbmap
   - bbmap/filterbyname
+  - bbmap
   files:
   - path: output/bbmap/test.fasta
     md5sum: b03f20541df9eb3053f8fb507a6c124f
@@ -11,8 +11,8 @@
 - name: bbmap filterbyname test_bbmap_filterbyname_single_end
   command: nextflow run ./tests/modules/nf-core/bbmap/filterbyname -entry test_bbmap_filterbyname_single_end -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/bbmap/filterbyname/nextflow.config
   tags:
-  - bbmap
   - bbmap/filterbyname
+  - bbmap
   files:
   - path: output/bbmap/test.fastq.gz
     md5sum: ddc04fd7fd192c9c61aea553d50669e0

--- a/tests/modules/nf-core/bbmap/filterbyname/test.yml
+++ b/tests/modules/nf-core/bbmap/filterbyname/test.yml
@@ -1,21 +1,21 @@
 - name: bbmap filterbyname test_bbmap_filterbyname_paired_end
   command: nextflow run ./tests/modules/nf-core/bbmap/filterbyname -entry test_bbmap_filterbyname_paired_end -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/bbmap/filterbyname/nextflow.config
   tags:
-    - bbmap/filterbyname
-    - bbmap
+  - bbmap
+  - bbmap/filterbyname
   files:
-    - path: output/bbmap/test.filterbyname.log
-    - path: output/bbmap/test_1.fa
-      md5sum: 48d7966ba16abd5b4361d7ad9867ef79
-    - path: output/bbmap/test_2.fa
-      md5sum: bfcf3323955fad0d7bc53c9fff9f228e
+  - path: output/bbmap/test.fasta
+    md5sum: b03f20541df9eb3053f8fb507a6c124f
+  - path: output/bbmap/test.filterbyname.log
+    contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'
 
 - name: bbmap filterbyname test_bbmap_filterbyname_single_end
   command: nextflow run ./tests/modules/nf-core/bbmap/filterbyname -entry test_bbmap_filterbyname_single_end -c ./tests/config/nextflow.config -c ./tests/modules/nf-core/bbmap/filterbyname/nextflow.config
   tags:
-    - bbmap/filterbyname
-    - bbmap
+  - bbmap
+  - bbmap/filterbyname
   files:
-    - path: output/bbmap/test.fa
-      md5sum: 48d7966ba16abd5b4361d7ad9867ef79
-    - path: output/bbmap/test.filterbyname.log
+  - path: output/bbmap/test.fastq.gz
+    md5sum: ddc04fd7fd192c9c61aea553d50669e0
+  - path: output/bbmap/test.filterbyname.log
+    contains: '[ # TODO nf-core: file md5sum was variable, please replace this text with a string found in the file instead ]'


### PR DESCRIPTION
- Switched to using `args` instead of passing `output_extension` directly to `input`
- Now supporting interleaved output (`interleaved_output` inside `args`)
- Updated BBmap to the newest version ([39.01-h311275f_0](https://anaconda.org/bioconda/bbmap/39.01/download/osx-64/bbmap-39.01-h311275f_0.tar.bz2))